### PR TITLE
Adding missing GuzzleHttp\Psr7 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
   ],
   "require": {
     "ext-json": "*",
-    "bbaga/buildkite-php-http-interface": "^1.0"
+    "bbaga/buildkite-php-http-interface": "^1.0",
+    "guzzlehttp/psr7": "^1.6"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
`GuzzleHttp\Psr7\stream_for` is a hard dependency for the time being